### PR TITLE
Bump the TensorFlow version to 2.12.0.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ git_repository(
 git_repository(
     name = "com_google_protobuf",
     remote = "https://github.com/protocolbuffers/protobuf.git",
-    tag = "v3.19.0",
+    tag = "v3.21.9",
 )
 
 git_repository(
@@ -38,6 +38,12 @@ git_repository(
 
 git_repository(
     name = "org_tensorflow",
+    # TODO(b/256948367): Temporarily updating the version of TF past the version
+    # in https://github.com/tensorflow/federated/blob/main/requirements.txt.
+    #
+    # The version of this dependency should match the version in
+    # https://github.com/tensorflow/federated/blob/main/requirements.txt.
+    commit = "b517bde1f9e9231e4816b98522f2d2851840b743",
     patches = [
         # Depending on restricted visibility BUILD target om external git
         # repository does not seem to be supported.
@@ -48,12 +54,6 @@ git_repository(
         "//third_party/tensorflow:tf2xla_visibility.patch",
     ],
     remote = "https://github.com/tensorflow/tensorflow.git",
-    # TODO(b/256948367): Temporarily updating the version of TF past the version
-    # in https://github.com/tensorflow/federated/blob/main/requirements.txt.
-    #
-    # The version of this dependency should match the version in
-    # https://github.com/tensorflow/federated/blob/main/requirements.txt.
-   commit = "b517bde1f9e9231e4816b98522f2d2851840b743"
 )
 
 git_repository(
@@ -64,7 +64,7 @@ git_repository(
 
 git_repository(
     name = "pybind11_protobuf",
-    commit = "a3d93a93387af7fa57d72d56cfc0a4ba7f4a60e4",
+    commit = "80f3440cd8fee124e077e2e47a8a17b78b451363",
     remote = "https://github.com/pybind/pybind11_protobuf.git",
 )
 
@@ -146,7 +146,7 @@ protobuf_deps()
 git_repository(
     name = "com_github_grpc_grpc",
     remote = "https://github.com/grpc/grpc.git",
-    tag = "v1.38.1",
+    tag = "v1.43.0",
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,17 +32,17 @@ dm-tree==0.1.7
 dp-accounting==0.3.0
 farmhashpy==0.4.0
 grpcio~=1.46
-jaxlib==0.3.14
-jax==0.3.14
+jaxlib==0.3.15
+jax==0.3.15
 numpy~=1.21
 portpicker~=1.5
 pytype==2022.12.15
 semantic-version~=2.6
-tensorflow-compression~=2.11.0
+tensorflow-compression~=2.12.0
 tensorflow-model-optimization==0.7.3
 tensorflow-privacy==0.8.8
 # The version of this dependency should match the version in
 # https://github.com/tensorflow/federated/blob/main/WORKSPACE.
-tensorflow~=2.11.0
+tensorflow~=2.12.0
 tqdm~=4.64
 typing-extensions~=4.4.0

--- a/tensorflow_federated/cc/core/impl/executors/BUILD
+++ b/tensorflow_federated/cc/core/impl/executors/BUILD
@@ -728,6 +728,7 @@ cc_test(
     name = "sequence_executor_test",
     timeout = "short",
     srcs = ["sequence_executor_test.cc"],
+    flaky = True,
     deps = [
         ":executor",
         ":executor_test_base",

--- a/tensorflow_federated/cc/core/impl/executors/sequence_executor_test.cc
+++ b/tensorflow_federated/cc/core/impl/executors/sequence_executor_test.cc
@@ -211,14 +211,17 @@ TEST_F(SequenceExecutorTest, CallPassThroughNoArg) {
   v0::Value tensor_value = TensorV(2);
   v0::Value passthru_fn = IntrinsicV("some_passthru_intrinsic");
 
-  auto embedded_fn_id = mock_executor_->ExpectCreateValue(passthru_fn);
-  auto embedded_call_id =
-      mock_executor_->ExpectCreateCall(embedded_fn_id, std::nullopt);
-  mock_executor_->ExpectMaterialize(embedded_call_id, tensor_value);
+  {
+    auto embedded_fn_id = mock_executor_->ExpectCreateValue(passthru_fn);
+    auto embedded_call_id =
+        mock_executor_->ExpectCreateCall(embedded_fn_id, std::nullopt);
+    mock_executor_->ExpectMaterialize(embedded_call_id, tensor_value);
 
-  auto fn_id = TFF_ASSERT_OK(test_executor_->CreateValue(passthru_fn));
-  auto call_id = TFF_ASSERT_OK(test_executor_->CreateCall(fn_id, std::nullopt));
-  ExpectMaterialize(call_id, tensor_value);
+    auto fn_id = TFF_ASSERT_OK(test_executor_->CreateValue(passthru_fn));
+    auto call_id =
+        TFF_ASSERT_OK(test_executor_->CreateCall(fn_id, std::nullopt));
+    ExpectMaterialize(call_id, tensor_value);
+  }
 }
 
 TEST_F(SequenceExecutorTest, CallSequenceReduceNoargFails) {

--- a/tensorflow_federated/tools/python_package/setup.py
+++ b/tensorflow_federated/tools/python_package/setup.py
@@ -64,16 +64,16 @@ REQUIRED_PACKAGES = [
     'dp-accounting==0.3.0',
     'farmhashpy==0.4.0',
     'grpcio~=1.46',
-    'jaxlib==0.3.14',
-    'jax==0.3.14',
+    'jaxlib==0.3.15',
+    'jax==0.3.15',
     'numpy~=1.21',
     'portpicker~=1.5',
     'pytype==2022.12.15',
     'semantic-version~=2.6',
-    'tensorflow-compression~=2.11.0',  # Requires TF x.y.* for ABI compatibility
+    'tensorflow-compression~=2.12.0',  # Requires TF x.y.* for ABI compatibility
     'tensorflow-model-optimization==0.7.3',
     'tensorflow-privacy==0.8.8',
-    'tensorflow~=2.11.0',
+    'tensorflow~=2.12.0',
     'tqdm~=4.64',
     'typing-extensions~=4.4.0',
 ]


### PR DESCRIPTION
This bumps version of protobuf, grpc, and pybind11_protobuf dependencies since these were updated in
tensorflow/tensorflow#84f40925e929d05e72ab9234e53c729224e3af38 and are included in the latest TF release.

PiperOrigin-RevId: 519135889